### PR TITLE
Add remote control MCP tools for Renew devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -976,12 +976,12 @@
       }
     },
     "node_modules/airthings-consumer-api": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/airthings-consumer-api/-/airthings-consumer-api-1.2.0.tgz",
-      "integrity": "sha512-YvGElkngn/qIuZ/8IJEv1hOxAy2Nxz8j0zrA4/PYMtDOy6t0UtRa8ybO67Kz42Xv7a9dj7ggYztb2bcDrI8LZA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/airthings-consumer-api/-/airthings-consumer-api-1.3.0.tgz",
+      "integrity": "sha512-S/K1KiHUpd8mYMto3MleqJ5xYRJvfRT3Z7EOxpsllRmFfYRg2EwYJTweTiB4LrxQNxFuazHXJZLA4Ju0O6jxDQ==",
       "license": "ISC",
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/ajv": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,9 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { AirthingsClient, SensorUnits } from 'airthings-consumer-api';
+import { AirthingsClient, RemoteControlMode, SensorUnits } from 'airthings-consumer-api';
+import type { RemoteControlState } from 'airthings-consumer-api';
+import { z } from 'zod';
 import { readFileSync } from 'node:fs';
 
 const clientId = process.env.AIRTHINGS_CLIENT_ID;
@@ -57,6 +59,60 @@ server.tool(
             content: [{
                 type: 'text',
                 text: lines.join('\n')
+            }]
+        };
+    }
+);
+
+server.tool(
+    'airthings-remote-control-get',
+    'Get the current remote control state of an Airthings Renew air purifier.',
+    {
+        serialNumber: z.string().describe('The serial number of the Renew device')
+    },
+    async ({ serialNumber }) => {
+        const state = await client.getRemoteControl(serialNumber);
+
+        let text = `Mode: ${state.mode}`;
+        if (state.fanSpeed !== undefined) {
+            text += `\nFan Speed: ${state.fanSpeed}`;
+        }
+
+        return {
+            content: [{
+                type: 'text' as const,
+                text
+            }]
+        };
+    }
+);
+
+server.tool(
+    'airthings-remote-control-set',
+    'Set the remote control mode of an Airthings Renew air purifier. Available modes: OFF, AUTO, SLEEP, BOOST, MANUAL. Fan speed (1-5) is required for MANUAL mode.',
+    {
+        serialNumber: z.string().describe('The serial number of the Renew device'),
+        mode: z.nativeEnum(RemoteControlMode).describe('The operational mode to set'),
+        fanSpeed: z.number().min(1).max(5).optional().describe('Fan speed level (1-5), required for MANUAL mode')
+    },
+    async ({ serialNumber, mode, fanSpeed }) => {
+        const state: RemoteControlState = { mode };
+        if (fanSpeed !== undefined) {
+            state.fanSpeed = fanSpeed;
+        }
+
+        await client.setRemoteControl(serialNumber, state);
+
+        let text = `Successfully set ${serialNumber} to ${mode} mode`;
+        if (fanSpeed !== undefined) {
+            text += ` at fan speed ${fanSpeed}`;
+        }
+        text += '.';
+
+        return {
+            content: [{
+                type: 'text' as const,
+                text
             }]
         };
     }


### PR DESCRIPTION
## Summary
- Adds `airthings-remote-control-get` tool to query device state
- Adds `airthings-remote-control-set` tool to set device mode (OFF, AUTO, SLEEP, BOOST, MANUAL with fan speed)
- Uses zod schemas for input validation with descriptive parameter metadata

**Depends on:** michaelahern/airthings-consumer-api#46 (new `getRemoteControl`/`setRemoteControl` methods must be published first)

## Test plan
- [ ] Verify `airthings-remote-control-get` returns formatted mode/fan speed
- [ ] Verify `airthings-remote-control-set` accepts valid modes and fan speed
- [ ] Verify input validation rejects invalid modes and out-of-range fan speeds
- [ ] Integration test with real Renew device after API client update

🤖 Generated with [Claude Code](https://claude.com/claude-code)